### PR TITLE
minor : fix padding problem on iphone 5

### DIFF
--- a/_sass/_vendor.scss
+++ b/_sass/_vendor.scss
@@ -150,6 +150,17 @@ a.button:active {
     padding: 0;
   }
 }
+/* Portrait iPhone 5 series */
+@media only screen
+  and (min-device-width: 320px)
+  and (max-device-width: 568px)
+  and (-webkit-min-device-pixel-ratio: 2)
+  and (orientation: portrait) {
+    .panel {
+      padding: 5vh 0 5vh 0 !important;
+    }
+}
+
 @media (min-width: 550px) {
   .container {
     width: 80%;


### PR DESCRIPTION
Gift boxes were not correctly centered using iphone 5 : 

<img width="433" alt="capture d ecran 2017-11-28 a 13 44 23" src="https://user-images.githubusercontent.com/5587278/33320368-4b1cd4a0-d442-11e7-9211-a73cb8608cb2.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/etalab/calendrier-lavent/3)
<!-- Reviewable:end -->
